### PR TITLE
Supports workers as configuration option

### DIFF
--- a/Tentacle/readme.md
+++ b/Tentacle/readme.md
@@ -48,6 +48,7 @@ docker run --publish 10931:10933 --tty --interactive --env "ListeningPort=10931"
 - **ServerUrl**: The Url of the Octopus Server the Tentacle should register with.
 - **TargetEnvironment**: Comma delimited list of environments to add this target to.
 - **TargetRole**: Comma delimited list of roles to add to this target.
+- **TargetWorkerPool**: Comma delimited list of worker pools to add to this target to (not to be used with environments or role variable).
 - **TargetName**: Optional Target name, defaults to host.
 - **ServerPort**: The port on the Octopus Server that the Tentacle will poll for work. Implies a polling Tentacle.
 - **ListeningPort**: The port that the Octopus Server will connect back to the Tentacle with. Defaults to 10933. Implies a listening Tentacle.


### PR DESCRIPTION
This PR allows specifying the WorkerPool environment variable to allow for adding tentacles to a worker pool.  Checks are made to ensure the correct combination of environment options, as environments and roles are not valid for worker pool registration.  I have tested this on my own tentacle Docker images.