### PR TITLE
Fix error 'The request was aborted: Could not create SSL/TLS secure channel' when trying to download Octopus Tentacle .msi file.

### DIFF
--- a/Scripts/installers.ps1
+++ b/Scripts/installers.ps1
@@ -14,7 +14,7 @@ function Stage-Installer {
     }
 
 	Write-Log "Downloading installer '$downloadUrl' to '$MsiPath' ..."
-  [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+  [Net.ServicePointManager]::SecurityProtocol += [Net.SecurityProtocolType]::Tls12
 	(New-Object Net.WebClient).DownloadFile($downloadUrl, $MsiPath)
     Write-Log "done."
 }

--- a/Scripts/installers.ps1
+++ b/Scripts/installers.ps1
@@ -14,6 +14,7 @@ function Stage-Installer {
     }
 
 	Write-Log "Downloading installer '$downloadUrl' to '$MsiPath' ..."
+  [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 	(New-Object Net.WebClient).DownloadFile($downloadUrl, $MsiPath)
     Write-Log "done."
 }


### PR DESCRIPTION
When I tried to build current Dockerfile from **master** branch, I got an error indicating :

`The request was aborted: Could not create SSL/TLS secure channel`

I spent some time investigating but wasn't able to determine why this happened in my case. So, after investigating it a little on the web, I found a [proposal](https://stackoverflow.com/a/41618979/696790) on how to overcome this error, tried it and this time the build succeeded.

After this issue had been resolved, I decided to create this pull request, because probably there are more people out there that will or have already faced this issue.

Feel free to contact me in case you have any objection or question about.