### PR TITLE
Pass machine ids to ExecuteCalamariUpdate

### DIFF
--- a/Tentacle/Tests/OctopusRegistration.Tests.ps1
+++ b/Tentacle/Tests/OctopusRegistration.Tests.ps1
@@ -34,7 +34,10 @@ Describe 'Octopus Registration' {
 
 	$repository.Users.SignIn($LoginObj)
 
-	$task = $repository.Tasks.ExecuteCalamariUpdate();
+	$machines = $repository.Machines.FindAll()
+	$machineIds = ,$machines.Id
+
+	$task = $repository.Tasks.ExecuteCalamariUpdate($null, $machineIds);
 	$repository.Tasks.WaitForCompletion($task, 4, 3);
 
 	$task = $repository.Tasks.ExecuteHealthCheck();


### PR DESCRIPTION
In theory, the ExecuteCalamariUpdate task should treat "no machines specified" as "all machines specified", but there's a bug (https://github.com/OctopusDeploy/Issues/issues/5263 & https://github.com/OctopusDeploy/Issues/issues/5276)  so we need to specify the machine ids for it to work.