### PR TITLE
Add script to set the export file version to the current version so migrator won't complain

### DIFF
--- a/Server/00-set-metadata-version.ps1
+++ b/Server/00-set-metadata-version.ps1
@@ -1,0 +1,14 @@
+param (
+  [Parameter(Mandatory=$true)]
+  [string]$OctopusVersion
+)
+
+. ./Scripts/build-common.ps1
+
+Confirm-RunningFromRootDirectory
+
+TeamCity-Block("Setting metadata version to current") {
+    $filePath = './Testing/Import/metadata.json'
+
+    ((Get-Content -path $filePath -Raw) -replace '"DatabaseVersion": "0.0.0"', ('"DatabaseVersion": "'+$OctopusVersion+'"')) | Set-Content -Path $filePath   
+}


### PR DESCRIPTION
I'm adding a version check in Migrator so that it errors when the version `metadata.json` doesn't match the instance version. 

The [Docker build](https://build.octopushq.com/viewLog.html?buildId=1081811&buildTypeId=OctopusDeploy_OctopusServer_Docker_BuildWin2016&tab=buildLog&branch_OctopusDeploy_OctopusServer_Docker=%3Cdefault%3E&_focus=81#_state=81) fails because it tries to import a `metadata.json` with a `0.0.0` version. Ideally we'd call Migrator with the `--ignore-version-check` flag, but old versions of Migrator won't work with this.

The workaround for now is to always set the version in `metadata.json` to the current version.

We can remove this once we move all our Docker scripts to the `OctopusDeploy` repo where we can branch the scripts and use the new `--ignore-version-check` flag.