### PR TITLE
Fix stopping/cleanup logic.

### DIFF
--- a/Scripts/build-common.ps1
+++ b/Scripts/build-common.ps1
@@ -71,6 +71,24 @@ function Start-DockerCompose($projectName, $composeFile) {
   }
 }
 
+function Stop-DockerCompose($projectName) {
+  write-host "Stopping $projectName compose project"
+  & docker-compose --file .\Server\docker-compose.yml --project-name $ProjectName stop
+
+  write-host "Removing $projectName compose project"
+  & docker-compose --file .\Server\docker-compose.yml --project-name $ProjectName down
+
+  # docker-compose down doesn't always clean up properly.
+  # Make sure the containers are removed.
+  & docker rm -f $projectName"_octopus_1"
+  & docker rm -f $projectName"_db_1"
+  
+  if(!$(Test-RunningUnderTeamCity) -and (Test-Path .\Temp)) {
+    Write-Host "Cleaning up Temp"
+    Remove-Item .\Temp -Recurse -Force
+  }
+}
+
 function Wait-ForServiceToPassHealthCheck($serviceName) {
   $attempts = 0;
   $sleepsecs = 10;

--- a/Scripts/build-common.ps1
+++ b/Scripts/build-common.ps1
@@ -71,18 +71,22 @@ function Start-DockerCompose($projectName, $composeFile) {
   }
 }
 
-function Stop-DockerCompose($projectName) {
+function Stop-DockerCompose($projectName, $composeFile) {
   write-host "Stopping $projectName compose project"
-  & docker-compose --file .\Server\docker-compose.yml --project-name $ProjectName stop
+  & docker-compose --file $composeFile --project-name $ProjectName stop
 
   write-host "Removing $projectName compose project"
-  & docker-compose --file .\Server\docker-compose.yml --project-name $ProjectName down
+  & docker-compose --file $composeFile --project-name $ProjectName down --remove-orphans
 
   # docker-compose down doesn't always clean up properly.
   # Make sure the containers are removed.
-  & docker rm -f $projectName"_octopus_1"
-  & docker rm -f $projectName"_db_1"
-  
+  write-host "Removing any remaining containers"
+  $dockerContainers = $(docker ps -a -q)
+  if ($null -ne $dockerContainers) { 
+    docker kill -f $dockerContainers
+    docker rm -f $dockerContainers
+  }
+
   if(!$(Test-RunningUnderTeamCity) -and (Test-Path .\Temp)) {
     Write-Host "Cleaning up Temp"
     Remove-Item .\Temp -Recurse -Force

--- a/Server/02-start.ps1
+++ b/Server/02-start.ps1
@@ -15,12 +15,16 @@ $OctopusServerContainer= $ProjectName+"_octopus_1";
 $env:OCTOPUS_VERSION=Get-ImageVersion $OctopusVersion $OSVersion;
 $env:OCTOPUS_SERVER_REPO_SUFFIX="-prerelease"
 $env:SERVERCORE_VERSION=$OSVersion
-$env:OCTOPUS_SKIP_IMPORT_VERSION_CHECK="true"
+$env:OCTOPUS_SKIP_IMPORT_VERSION_CHECK="false"
 
 if ($OSVersion -eq "ltsc2016") {
     $env:SQL_IMAGE="microsoft/mssql-server-windows-express"
 } else { #Microsoft is being rather lax in keeping the official microsoft/mssql-server-windows-express repo up to date
     $env:SQL_IMAGE="octopusdeploy/mssql-server-windows-express:$OSVersion"
+}
+
+TeamCity-Block("Ensure containers are stopped") {
+    Stop-DockerCompose($ProjectName)
 }
 
 TeamCity-Block("Start containers") {

--- a/Server/02-start.ps1
+++ b/Server/02-start.ps1
@@ -24,7 +24,7 @@ if ($OSVersion -eq "ltsc2016") {
 }
 
 TeamCity-Block("Ensure containers are stopped") {
-    Stop-DockerCompose($ProjectName)
+    Stop-DockerCompose $ProjectName .\Server\docker-compose.yml
 }
 
 TeamCity-Block("Start containers") {

--- a/Server/04-stop.ps1
+++ b/Server/04-stop.ps1
@@ -7,5 +7,5 @@ param (
 Confirm-RunningFromRootDirectory
 
 TeamCity-Block("Stop and remove compose project") {
-  Stop-DockerCompose($ProjectName)
+  Stop-DockerCompose $ProjectName .\Server\docker-compose.yml
 }

--- a/Server/04-stop.ps1
+++ b/Server/04-stop.ps1
@@ -7,15 +7,5 @@ param (
 Confirm-RunningFromRootDirectory
 
 TeamCity-Block("Stop and remove compose project") {
-    
-    write-host "Stopping $ProjectName compose project"
-    & docker-compose --file .\Server\docker-compose.yml --project-name $ProjectName stop
-    
-    write-host "Removing $ProjectName compose project"
-    & docker-compose --file .\Server\docker-compose.yml --project-name $ProjectName down
-
-    if(!$(Test-RunningUnderTeamCity) -and (Test-Path .\Temp)) {
-      Write-Host "Cleaning up Temp"
-      Remove-Item .\Temp -Recurse -Force
-    }
+  Stop-DockerCompose($ProjectName)
 }

--- a/Tentacle/00-set-metadata-version.ps1
+++ b/Tentacle/00-set-metadata-version.ps1
@@ -1,0 +1,40 @@
+param (
+  [Parameter(Mandatory=$false)]
+  [string]$OctopusVersion="latest"
+)
+
+. ./Scripts/build-common.ps1
+
+function DetermineActualServerVersion($version){
+
+	$dockerImage = "octopusdeploy/octopusdeploy:$version"
+	$searchFor = "OctopusVersion=";
+
+	if ("latest" -eq $version){
+        & docker image pull -q $dockerImage > $null
+        $json = (& docker image inspect octopusdeploy/octopusdeploy:$version | convertfrom-json)
+		$envVarString = $json[0].ContainerConfig.Env | Where-Object { $_ -like "$searchFor*" } | Select-Object -First 1
+
+		if ($null -eq $envVarString){
+			return $null
+		}
+
+        return $envVarString.Substring($searchFor.Length)
+
+	} else {
+		return $version;
+	}
+}
+
+TeamCity-Block("Setting metadata version") {
+    $actualVersion = DetermineActualServerVersion($OctopusVersion)
+
+    if ($null -eq $actualVersion){
+        write-host "Could not determine the actual version of Octopus Server."
+    } else {
+        write-host "Determined version of Octopus Server to be: $actualVersion"
+
+        $filePath = './Testing/Import/metadata.json'
+        ((Get-Content -path $filePath -Raw) -replace '"DatabaseVersion": "0.0.0"', ('"DatabaseVersion": "'+$actualVersion+'"')) | Set-Content -Path $filePath   
+    }
+}

--- a/Tentacle/00-set-metadata-version.ps1
+++ b/Tentacle/00-set-metadata-version.ps1
@@ -7,13 +7,13 @@ param (
 
 function DetermineActualServerVersion($version){
 
-	$dockerImage = "octopusdeploy/octopusdeploy:$version"
-	$searchFor = "OctopusVersion=";
+    $dockerImage = "octopusdeploy/octopusdeploy:$version"
+    $searchFor = "OctopusVersion=";
 
 	if ("latest" -eq $version){
         & docker image pull -q $dockerImage > $null
         $json = (& docker image inspect octopusdeploy/octopusdeploy:$version | convertfrom-json)
-		$envVarString = $json[0].ContainerConfig.Env | Where-Object { $_ -like "$searchFor*" } | Select-Object -First 1
+        $envVarString = $json[0].ContainerConfig.Env | Where-Object { $_ -like "$searchFor*" } | Select-Object -First 1
 
 		if ($null -eq $envVarString){
 			return $null
@@ -22,8 +22,8 @@ function DetermineActualServerVersion($version){
         return $envVarString.Substring($searchFor.Length)
 
 	} else {
-		return $version;
-	}
+        return $version;
+    }
 }
 
 TeamCity-Block("Setting metadata version") {

--- a/Tentacle/00-set-metadata-version.ps1
+++ b/Tentacle/00-set-metadata-version.ps1
@@ -1,6 +1,6 @@
 param (
-  [Parameter(Mandatory=$false)]
-  [string]$OctopusVersion="latest"
+    [Parameter(Mandatory=$false)]
+    [string]$OctopusVersion="latest"
 )
 
 . ./Scripts/build-common.ps1
@@ -10,18 +10,18 @@ function DetermineActualServerVersion($version){
     $dockerImage = "octopusdeploy/octopusdeploy:$version"
     $searchFor = "OctopusVersion=";
 
-	if ("latest" -eq $version){
+    if ("latest" -eq $version){
         & docker image pull -q $dockerImage > $null
         $json = (& docker image inspect octopusdeploy/octopusdeploy:$version | convertfrom-json)
         $envVarString = $json[0].ContainerConfig.Env | Where-Object { $_ -like "$searchFor*" } | Select-Object -First 1
 
-		if ($null -eq $envVarString){
-			return $null
-		}
+    if ($null -eq $envVarString){
+        return $null
+    }
 
         return $envVarString.Substring($searchFor.Length)
 
-	} else {
+    } else {
         return $version;
     }
 }

--- a/Tentacle/00-set-metadata-version.ps1
+++ b/Tentacle/00-set-metadata-version.ps1
@@ -1,40 +1,39 @@
 param (
-    [Parameter(Mandatory=$false)]
-    [string]$OctopusVersion="latest"
+  [Parameter(Mandatory=$false)]
+  [string]$OctopusVersion="latest"
 )
 
 . ./Scripts/build-common.ps1
 
-function DetermineActualServerVersion($version){
+function Get-OctopusServerVersion($version){
+  $dockerImage = "octopusdeploy/octopusdeploy:$version"
+  $searchFor = "OctopusVersion=";
 
-    $dockerImage = "octopusdeploy/octopusdeploy:$version"
-    $searchFor = "OctopusVersion=";
-
-    if ("latest" -eq $version){
-        & docker image pull -q $dockerImage > $null
-        $json = (& docker image inspect octopusdeploy/octopusdeploy:$version | convertfrom-json)
-        $envVarString = $json[0].ContainerConfig.Env | Where-Object { $_ -like "$searchFor*" } | Select-Object -First 1
+  if ("latest" -eq $version){
+    & docker image pull -q $dockerImage > $null
+    $json = (& docker image inspect octopusdeploy/octopusdeploy:$version | convertfrom-json)
+    $envVarString = $json[0].ContainerConfig.Env | Where-Object { $_ -like "$searchFor*" } | Select-Object -First 1
 
     if ($null -eq $envVarString){
-        return $null
+      return $null
     }
 
-        return $envVarString.Substring($searchFor.Length)
+    return $envVarString.Substring($searchFor.Length)
 
-    } else {
-        return $version;
-    }
+  } else {
+    return $version;
+  }
 }
 
 TeamCity-Block("Setting metadata version") {
-    $actualVersion = DetermineActualServerVersion($OctopusVersion)
+  $actualVersion = Get-OctopusServerVersion($OctopusVersion)
 
-    if ($null -eq $actualVersion){
-        write-host "Could not determine the actual version of Octopus Server."
-    } else {
-        write-host "Determined version of Octopus Server to be: $actualVersion"
+  if ($null -eq $actualVersion){
+    write-host "Could not determine the actual version of Octopus Server."
+  } else {
+    write-host "Determined version of Octopus Server to be: $actualVersion"
 
-        $filePath = './Testing/Import/metadata.json'
-        ((Get-Content -path $filePath -Raw) -replace '"DatabaseVersion": "0.0.0"', ('"DatabaseVersion": "'+$actualVersion+'"')) | Set-Content -Path $filePath   
-    }
+    $filePath = './Testing/Import/metadata.json'
+    ((Get-Content -path $filePath -Raw) -replace '"DatabaseVersion": "0.0.0"', ('"DatabaseVersion": "'+$actualVersion+'"')) | Set-Content -Path $filePath   
+  }
 }

--- a/Tentacle/02-start.ps1
+++ b/Tentacle/02-start.ps1
@@ -17,7 +17,7 @@ $env:OCTOPUS_TENTACLE_REPO_SUFFIX = "-prerelease"
 $OctopusServerContainer=$ProjectName+"_octopus_1";
 $ListeningTentacleServiceName=$ProjectName+"_listeningtentacle_1";
 $PollingTentacleServiceName=$ProjectName+"_pollingtentacle_1";
-$env:OCTOPUS_SKIP_IMPORT_VERSION_CHECK="true"
+$env:OCTOPUS_SKIP_IMPORT_VERSION_CHECK="false"
 
 Confirm-RunningFromRootDirectory
 
@@ -25,6 +25,10 @@ if ($OSVersion -eq "ltsc2016") {
     $env:SQL_IMAGE="microsoft/mssql-server-windows-express"
 } else { #Microsoft is being rather lax in keeping the official microsoft/mssql-server-windows-express repo up to date
     $env:SQL_IMAGE="octopusdeploy/mssql-server-windows-express:$OSVersion"
+}
+
+TeamCity-Block("Ensure containers are stopped") {
+    Stop-DockerCompose $ProjectName .\Tentacle\docker-compose.yml
 }
 
 TeamCity-Block("Start containers") {

--- a/Tentacle/04-stop.ps1
+++ b/Tentacle/04-stop.ps1
@@ -7,18 +7,5 @@ param (
 Confirm-RunningFromRootDirectory
 
 TeamCity-Block("Stop and remove compose project") {
-
-    write-host "Stopping $ProjectName compose project"
-    & docker-compose --file .\Server\docker-compose.yml --project-name $ProjectName stop
-
-    write-host "Removing $ProjectName compose project"
-    & docker-compose --file .\Server\docker-compose.yml --project-name $ProjectName down
-
-    write-host "Killing any remaining containers"
-    docker kill $(docker ps -q)
-
-    if(!$(Test-RunningUnderTeamCity) -and (Test-Path .\Temp)) {
-      Write-Host "Cleaning up Temp"
-      Remove-Item .\Temp -Recurse -Force
-    }
+    Stop-DockerCompose $ProjectName .\Tentacle\docker-compose.yml
 }


### PR DESCRIPTION
This PR changes the following:

- Makes sure that all containers are stopped and removed in the `04-stop.ps1` script.
- Attempts to stop and remove existing containers in `02-start.ps1` before starting up new ones, in case the previous build did not clean up properly.
- Removes the `--ignore-version-check` argument, because it:
  - Should no longer be necessary now that containers are cleaned up appropriately
  - Only works with version `2019.9.x` and above, which is breaking LTS builds at the moment.